### PR TITLE
Fix can_ground_jump() returning true when player falls off cliff

### DIFF
--- a/platformer_controller/platformer_controller.gd
+++ b/platformer_controller/platformer_controller.gd
@@ -152,7 +152,7 @@ func _input(_event):
 
 
 func _physics_process(delta):
-	if is_coyote_timer_running() or current_jump_type == JumpType.NONE:
+	if is_coyote_timer_running() or (is_feet_on_ground() and current_jump_type == JumpType.NONE):
 		jumps_left = max_jump_amount
 	if is_feet_on_ground() and current_jump_type == JumpType.NONE:
 		start_coyote_timer()
@@ -160,6 +160,7 @@ func _physics_process(delta):
 	# Check if we just hit the ground this frame
 	if not _was_on_ground and is_feet_on_ground():
 		current_jump_type = JumpType.NONE
+		jumps_left = max_jump_amount
 		if is_jump_buffer_timer_running() and not can_hold_jump: 
 			jump()
 		
@@ -211,9 +212,10 @@ func is_jump_buffer_timer_running():
 
 
 func can_ground_jump() -> bool:
-	if jumps_left > 0 and current_jump_type == JumpType.NONE:
-		return true
-	elif is_coyote_timer_running():
+	if jumps_left <= 0:
+		return false
+	
+	if (current_jump_type == JumpType.NONE and is_feet_on_ground()) or is_coyote_timer_running():
 		return true
 	
 	return false


### PR DESCRIPTION
This PR fixes a bug where the can_ground_jump() function returns true when the player falls off a cliff and is still in the air. This bug happened because `current_jump_type == JumpType.NONE` was being used to check if the player is on the ground, when in reality is still returns true after the player falls off a cliff and is in the air.